### PR TITLE
Configuration binding & validation

### DIFF
--- a/BinanceBot.Tests/OrderExecutorDryRunTests.cs
+++ b/BinanceBot.Tests/OrderExecutorDryRunTests.cs
@@ -43,7 +43,7 @@ public class OrderExecutorDryRunTests
     public async Task DryRunDoesNotCallSignedEndpoints()
     {
         var exchange = new FakeExchangeClient();
-        var settings = AppSettings.Load();
+        var settings = new AppSettings { ApiKey = "test", ApiSecret = "test" };
         var executor = new BracketOrderExecutor(exchange, settings, new BotOptions(true), new NoopAlertService());
         var filters = new SymbolFilters(0.001m, 0.1m, 5m);
 

--- a/BinanceBot.csproj
+++ b/BinanceBot.csproj
@@ -18,5 +18,6 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,44 @@ Set up optional Telegram notifications for entry, SL/TP hits, flips, and errors.
    export TELEGRAM_ALERTS_ENABLED=1
    ```
    Remove `TELEGRAM_ALERTS_ENABLED` or set it to another value to disable alerts.
-## Config (AppSettings)
+## Configuration
+
+Settings are bound using the Options pattern. Non-secret values come from
+`appsettings.{Environment}.json` files while API keys are read from environment
+variables.
+
+Hierarchy (lowest to highest):
+1. `appsettings.json` (optional)
+2. `appsettings.{Environment}.json`
+3. Environment variables (`BINANCE_API_KEY`, `BINANCE_API_SECRET`)
+
+Select environment via `DOTNET_ENVIRONMENT=Development` (default is
+`Production`). Copy one of the provided examples and adjust:
+
+```bash
+cp appsettings.Development.json.example appsettings.Development.json
+# or
+cp appsettings.Production.json.example appsettings.Production.json
+```
+
+Example `appsettings.Development.json`:
+
+```json
+{
+  "UseTestnet": true,
+  "Leverage": 3,
+  "RiskPerTradePct": 0.01,
+  "AtrMultiple": 1.5,
+  "Rrr": 2.0,
+  "FundingBlackoutMinutes": 10,
+  "AtrPercentileMin": 0,
+  "AtrPercentileMax": 100,
+  "Interval": "1h",
+  "Symbols": ["BTCUSDT","ETHUSDT"]
+}
+```
+
+### AppSettings
 - `UseTestnet`: `true` for dry-run
 - `Leverage`: e.g. `3`
 - `RiskPerTradePct`: e.g. `0.01` (1% risk)

--- a/appsettings.Production.json.example
+++ b/appsettings.Production.json.example
@@ -1,0 +1,12 @@
+{
+  "UseTestnet": false,
+  "Leverage": 3,
+  "RiskPerTradePct": 0.01,
+  "AtrMultiple": 1.5,
+  "Rrr": 2.0,
+  "FundingBlackoutMinutes": 10,
+  "AtrPercentileMin": 0,
+  "AtrPercentileMax": 100,
+  "Interval": "1h",
+  "Symbols": ["BTCUSDT","ETHUSDT"]
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,8 @@
 - **Scheduler:** 1-minute tick; acts on closed 1h candles
 
 ## Config & Secrets
-- `AppSettings.Load()` reads env vars for API Keys; defaults to Testnet; later move to `appsettings.*.json` if desired (secrets excluded from git)
+- Options pattern binds `AppSettings` from `appsettings.{Environment}.json`
+- API keys are injected via `BINANCE_API_KEY` / `BINANCE_API_SECRET` env vars
 
 ## Logging
 - Console logs for actions, errors, and filter clamps

--- a/src/Domain/Models.cs
+++ b/src/Domain/Models.cs
@@ -1,40 +1,42 @@
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.Configuration;
 
-public record AppSettings
+public class AppSettings
 {
-    public string ApiKey { get; init; } = Environment.GetEnvironmentVariable("BINANCE_API_KEY") ?? "YOUR_TESTNET_API_KEY";
-    public string ApiSecret { get; init; } = Environment.GetEnvironmentVariable("BINANCE_API_SECRET") ?? "YOUR_TESTNET_SECRET";
-    public bool UseTestnet { get; init; } = true;
-    public int Leverage { get; init; } = 3;
-    public decimal RiskPerTradePct { get; init; } = 0.01m;
-    public decimal AtrMultiple { get; init; } = 1.5m;
-    public decimal Rrr { get; init; } = 2.0m;
-    public decimal BreakEvenAtRr { get; init; } = 1.0m;
-    public decimal AtrTrailMultiple { get; init; } = 1.0m;
-    public string Interval { get; init; } = "1h";
-    public string[] Symbols { get; init; } = new[] { "BTCUSDT", "ETHUSDT" };
-    public int FundingBlackoutMinutes { get; init; } = 10;
-    public decimal AtrPercentileMin { get; init; } = 0m;
-    public decimal AtrPercentileMax { get; init; } = 100m;
+    [Required]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Required]
+    public string ApiSecret { get; set; } = string.Empty;
+
+    public bool UseTestnet { get; set; } = true;
+
+    public int Leverage { get; set; } = 3;
+
+    public decimal RiskPerTradePct { get; set; } = 0.01m;
+
+    public decimal AtrMultiple { get; set; } = 1.5m;
+
+    public decimal Rrr { get; set; } = 2.0m;
+
+    public decimal BreakEvenAtRr { get; set; } = 1.0m;
+
+    public decimal AtrTrailMultiple { get; set; } = 1.0m;
+
+    [Required]
+    public string Interval { get; set; } = "1h";
+
+    [MinLength(1)]
+    public string[] Symbols { get; set; } = new[] { "BTCUSDT", "ETHUSDT" };
+
+    public int FundingBlackoutMinutes { get; set; } = 10;
+
+    public decimal AtrPercentileMin { get; set; } = 0m;
+
+    public decimal AtrPercentileMax { get; set; } = 100m;
 
     [JsonIgnore]
     public string BaseUrl => UseTestnet ? "https://testnet.binancefuture.com" : "https://fapi.binance.com";
-
-    public static AppSettings Load(IConfiguration? config = null)
-    {
-        var settings = config?.Get<AppSettings>() ?? new AppSettings();
-
-        var apiKey = Environment.GetEnvironmentVariable("BINANCE_API_KEY");
-        var apiSecret = Environment.GetEnvironmentVariable("BINANCE_API_SECRET");
-
-        if (!string.IsNullOrWhiteSpace(apiKey))
-            settings = settings with { ApiKey = apiKey };
-        if (!string.IsNullOrWhiteSpace(apiSecret))
-            settings = settings with { ApiSecret = apiSecret };
-
-        return settings;
-    }
 }
 
 public record ServerTime(DateTimeOffset Time);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Application;
 using Infrastructure.Binance;
 using Infrastructure;
@@ -16,18 +17,32 @@ var builder = Host.CreateDefaultBuilder(args)
     .UseSerilog()
     .ConfigureServices((context, services) =>
     {
-        var settings = AppSettings.Load(context.Configuration);
-        services.AddSingleton(settings);
+        services.AddOptions<AppSettings>()
+            .Bind(context.Configuration)
+            .PostConfigure(s =>
+            {
+                s.ApiKey = Environment.GetEnvironmentVariable("BINANCE_API_KEY") ?? string.Empty;
+                s.ApiSecret = Environment.GetEnvironmentVariable("BINANCE_API_SECRET") ?? string.Empty;
+            })
+            .Validate(s => !string.IsNullOrWhiteSpace(s.ApiKey), "BINANCE_API_KEY is required")
+            .Validate(s => !string.IsNullOrWhiteSpace(s.ApiSecret), "BINANCE_API_SECRET is required")
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
-        services.AddSingleton<HttpClient>(_ =>
-            new HttpClient(new SocketsHttpHandler
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<AppSettings>>().Value);
+
+        services.AddSingleton<HttpClient>(sp =>
+        {
+            var settings = sp.GetRequiredService<AppSettings>();
+            return new HttpClient(new SocketsHttpHandler
             {
                 PooledConnectionLifetime = TimeSpan.FromMinutes(15),
                 AutomaticDecompression = DecompressionMethods.All
             })
             {
                 BaseAddress = new Uri(settings.BaseUrl)
-            });
+            };
+        });
 
         var alertsEnabled = Environment.GetEnvironmentVariable("TELEGRAM_ALERTS_ENABLED") == "1";
         if (alertsEnabled)


### PR DESCRIPTION
## Summary
- Bind AppSettings using the Options pattern with environment variable overrides for Binance API keys
- Validate required settings at startup via DataAnnotations and custom checks
- Document configuration hierarchy with development/production examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f14ad5b0833093f53b099b0eacc3