### PR TITLE
Docker & deployment (Ubuntu)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+# Multi-stage build for Binance Futures Bot
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# copy csproj and restore as distinct layers
+COPY BinanceBot.csproj ./
+RUN dotnet restore
+
+# copy source and publish
+COPY src ./src
+RUN dotnet publish BinanceBot.csproj -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish ./
+
+# logs are written to /app/logs; mount this as a volume
+VOLUME ["/app/logs"]
+
+ENTRYPOINT ["dotnet", "BinanceBot.dll"]

--- a/README.md
+++ b/README.md
@@ -96,5 +96,36 @@ Example `appsettings.Development.json`:
 - `docs/` technical docs (strategy, architecture, goals)
 - `.github/workflows/` CI
 
+## Deployment
+
+### Docker
+
+1. Copy one of the provided appsettings templates to `appsettings.Production.json` and adjust.
+2. Export environment variables:
+   - `BINANCE_API_KEY`
+   - `BINANCE_API_SECRET`
+   - *(optional)* `TELEGRAM_TOKEN`
+   - *(optional)* `TELEGRAM_CHAT_ID`
+   - *(optional)* `TELEGRAM_ALERTS_ENABLED=1`
+3. Build and run:
+   ```bash
+   docker compose up -d
+   ```
+   Logs are persisted in `./logs` on the host via a volume.
+
+The compose file also includes an optional [Seq](https://datalust.co/seq) container for structured log viewing.
+
+### systemd (Ubuntu)
+
+1. Publish the app to a folder, e.g. `/opt/binance-bot`.
+2. Edit `deploy/binance-bot.service` and set paths and environment variables.
+3. Install and start the service:
+   ```bash
+   sudo cp deploy/binance-bot.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now binance-bot.service
+   ```
+   Logs are written to `<working-directory>/logs`.
+
 ## License
 Proprietary – personal use.

--- a/deploy/binance-bot.service
+++ b/deploy/binance-bot.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Binance Futures Bot
+After=network.target
+
+[Service]
+# Adjust paths and user as needed
+WorkingDirectory=/opt/binance-bot
+ExecStart=/usr/bin/dotnet /opt/binance-bot/BinanceBot.dll
+Environment=BINANCE_API_KEY=REPLACE_ME
+Environment=BINANCE_API_SECRET=REPLACE_ME
+# Optional Telegram alerts
+# Environment=TELEGRAM_TOKEN=REPLACE_ME
+# Environment=TELEGRAM_CHAT_ID=REPLACE_ME
+# Environment=TELEGRAM_ALERTS_ENABLED=1
+Environment=DOTNET_ENVIRONMENT=Production
+# Logs are written to <WorkingDirectory>/logs
+Restart=always
+User=binancebot
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+
+services:
+  bot:
+    build: .
+    environment:
+      BINANCE_API_KEY: ${BINANCE_API_KEY}
+      BINANCE_API_SECRET: ${BINANCE_API_SECRET}
+      TELEGRAM_TOKEN: ${TELEGRAM_TOKEN:-}
+      TELEGRAM_CHAT_ID: ${TELEGRAM_CHAT_ID:-}
+      TELEGRAM_ALERTS_ENABLED: ${TELEGRAM_ALERTS_ENABLED:-0}
+      DOTNET_ENVIRONMENT: Production
+    volumes:
+      - ./logs:/app/logs
+      - ./appsettings.Production.json:/app/appsettings.Production.json:ro
+  seq:
+    image: datalust/seq:latest
+    environment:
+      ACCEPT_EULA: "Y"
+    ports:
+      - "5341:80"
+    volumes:
+      - seq-data:/data
+
+volumes:
+  seq-data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for building and running the bot
- provide docker-compose with log volume and optional Seq service
- include sample systemd unit and README deployment instructions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f89bd5c083309e32a7104f7702ea