### PR TITLE
Configure Binance base URL based on testnet option

### DIFF
--- a/src/Infrastructure/Binance/BinanceFuturesClient.cs
+++ b/src/Infrastructure/Binance/BinanceFuturesClient.cs
@@ -13,13 +13,18 @@ public class BinanceFuturesClient : IExchangeClient
     private readonly HttpClient _http;
     private readonly string _apiKey;
     private readonly string _secret;
+    private readonly string _baseUrl;
     private static readonly Random _jitter = new();
 
     public BinanceFuturesClient(HttpClient http, AppSettings settings)
     {
+        var options = new BinanceOptions(settings.UseTestnet);
+
         _http = http;
+        _http.BaseAddress = new Uri(options.BaseUrl);
         _apiKey = settings.ApiKey;
         _secret = settings.ApiSecret;
+        _baseUrl = options.BaseUrl;
     }
 
     public async Task<List<Kline>> GetKlinesAsync(string symbol, string interval, int limit = 500)

--- a/src/Infrastructure/Binance/BinanceOptions.cs
+++ b/src/Infrastructure/Binance/BinanceOptions.cs
@@ -1,0 +1,15 @@
+namespace Infrastructure.Binance;
+
+public class BinanceOptions
+{
+    public bool UseTestnet { get; }
+    public string BaseUrl { get; }
+
+    public BinanceOptions(bool useTestnet)
+    {
+        UseTestnet = useTestnet;
+        BaseUrl = useTestnet
+            ? "https://testnet.binancefuture.com"
+            : "https://fapi.binance.com";
+    }
+}


### PR DESCRIPTION
## Summary
- Set `BinanceFuturesClient` base address according to `UseTestnet`
- Introduce `BinanceOptions` to encapsulate Binance endpoint selection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a50876b08c8330a4da3728569beb4f