### PR TITLE
Add HMAC signer and inject into Binance client

### DIFF
--- a/src/Infrastructure/Binance/Signer.cs
+++ b/src/Infrastructure/Binance/Signer.cs
@@ -1,0 +1,21 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Infrastructure.Binance;
+
+public sealed class Signer
+{
+    private readonly byte[] _secret;
+    public Signer(string secret) => _secret = Encoding.UTF8.GetBytes(secret);
+
+    public string SignToHex(string message)
+    {
+        using var h = new HMACSHA256(_secret);
+        var data = Encoding.UTF8.GetBytes(message);
+        var hash = h.ComputeHash(data);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash) sb.Append(b.ToString("x2")); // lowercase hex
+        return sb.ToString();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add reusable HMAC SHA256 signer
- wire signer into BinanceFuturesClient and program startup
- configure BinanceOptions without mutating read-only properties

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a50d0f14ac8330a1f88e276c74585c