### PR TITLE
Add debug logging for position risk query

### DIFF
--- a/src/Infrastructure/Binance/BinanceFuturesClient.cs
+++ b/src/Infrastructure/Binance/BinanceFuturesClient.cs
@@ -161,7 +161,11 @@ public class BinanceFuturesClient : IExchangeClient
         var signature = _signer.SignToHex(encodedQuery);
         var finalQuery = $"{encodedQuery}&signature={signature}";
 
-        using var req = new HttpRequestMessage(HttpMethod.Get, path + "?" + finalQuery);
+        var url = path + "?" + finalQuery;
+        Log.Debug("GetPositionRisk query: nowMs={NowMs} encodedQuery={EncodedQuery} url={Url}",
+            nowMs, encodedQuery, url);
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, url);
         req.Headers.TryAddWithoutValidation("X-MBX-APIKEY", _apiKey);
 
         var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);


### PR DESCRIPTION
## Summary
- log encoded query, request URL, and timestamp in `GetPositionRiskAsync`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a50fa849ac8330bbd4d3314fd5405c