### PR TITLE
Add signing tests for Binance client

### DIFF
--- a/BinanceBot.sln
+++ b/BinanceBot.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinanceBot", "BinanceBot.cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinanceBot.Tests", "BinanceBot.Tests\BinanceBot.Tests.csproj", "{C9D088C3-C5FD-48F7-A946-F7F03B47F99F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{30F1D84A-7776-44B8-89F2-0719C266E87F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.Tests", "tests\Infrastructure.Tests\Infrastructure.Tests.csproj", "{635E507F-CF02-4B2F-B941-44C6F98BD8BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +28,12 @@ Global
 		{C9D088C3-C5FD-48F7-A946-F7F03B47F99F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9D088C3-C5FD-48F7-A946-F7F03B47F99F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9D088C3-C5FD-48F7-A946-F7F03B47F99F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{635E507F-CF02-4B2F-B941-44C6F98BD8BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{635E507F-CF02-4B2F-B941-44C6F98BD8BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{635E507F-CF02-4B2F-B941-44C6F98BD8BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{635E507F-CF02-4B2F-B941-44C6F98BD8BD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{635E507F-CF02-4B2F-B941-44C6F98BD8BD} = {30F1D84A-7776-44B8-89F2-0719C266E87F}
 	EndGlobalSection
 EndGlobal

--- a/tests/Infrastructure.Tests/BinanceSigningTests.cs
+++ b/tests/Infrastructure.Tests/BinanceSigningTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Net.Http;
+using System.Linq;
+using Infrastructure.Binance;
+using Xunit;
+
+namespace Infrastructure.Tests;
+
+public class BinanceSigningTests
+{
+    [Fact]
+    public void SignToHex_ComputesExpectedSignature()
+    {
+        const string secret = "testsecret";
+        var signer = new Signer(secret);
+        const string query = "recvWindow=5000&symbol=BTCUSDT&timestamp=1690000000000";
+        var sig = signer.SignToHex(query);
+        Assert.Equal("7cec10cb57fdea05659b3b4094a22ac97200ec3aac16ca3af568bae40e49b604", sig);
+    }
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = new();
+        private readonly Queue<HttpResponseMessage> _responses = new();
+
+        public void Enqueue(HttpResponseMessage response) => _responses.Enqueue(response);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            var resp = _responses.Count > 0 ? _responses.Dequeue() : new HttpResponseMessage(HttpStatusCode.OK);
+            return Task.FromResult(resp);
+        }
+    }
+
+    [Fact]
+    public async Task GetAccountBalanceAsync_HasApiKeyHeaderAndNoBody()
+    {
+        const string apiKey = "test-key";
+        var handler = new FakeHandler();
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"serverTime\":1690000000000}")
+        });
+        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("[]")
+        });
+
+        var http = new HttpClient(handler);
+        var settings = new AppSettings { ApiKey = apiKey, ApiSecret = "testsecret" };
+        var options = new BinanceOptions(true);
+        var signer = new Signer("testsecret");
+        var client = new BinanceFuturesClient(http, settings, options, signer);
+
+        await client.GetAccountBalanceAsync();
+
+        var req = handler.Requests.Last();
+        Assert.Equal(HttpMethod.Get, req.Method);
+        Assert.True(req.Headers.TryGetValues("X-MBX-APIKEY", out var values));
+        Assert.Equal(apiKey, Assert.Single(values));
+        Assert.Null(req.Content);
+    }
+}

--- a/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/tests/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\BinanceBot.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- test Signer.SignToHex against known signature
- ensure GET requests include API key header and no body

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a511f192d88330b34765fe7f867e77