### PR TITLE
chore: add RecvWindowMs setting for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ Thumbs.db
 
 # Secrets (never commit)
 appsettings.*.json
+!appsettings.Development.json
 *.key

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "UseTestnet": true,
+  "Leverage": 3,
+  "RiskPerTradePct": 0.01,
+  "AtrMultiple": 1.5,
+  "Rrr": 2.0,
+  "Interval": "1h",
+  "Symbols": ["BTCUSDT", "ETHUSDT"],
+  "Binance": {
+    "RecvWindowMs": 5000
+  }
+}


### PR DESCRIPTION
## Summary
- include RecvWindowMs in development settings for Binance API
- allow committing the development settings file

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a513409c4c8330b1dac67186716ee4