### PR TITLE
Add canonical signing and Binance time sync clock

### DIFF
--- a/src/Infrastructure/Binance/HttpResponseExtensions.cs
+++ b/src/Infrastructure/Binance/HttpResponseExtensions.cs
@@ -1,0 +1,15 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Infrastructure.Binance;
+
+public static class HttpResponseExtensions
+{
+    public static async Task EnsureSuccessOrThrowAsync(this HttpResponseMessage resp, CancellationToken ct = default)
+    {
+        if (resp.IsSuccessStatusCode) return;
+        var body = resp.Content != null ? await resp.Content.ReadAsStringAsync(ct) : string.Empty;
+        throw new HttpRequestException($"{(int)resp.StatusCode} {resp.ReasonPhrase} | {body}");
+    }
+}

--- a/src/Infrastructure/Binance/SystemClock.cs
+++ b/src/Infrastructure/Binance/SystemClock.cs
@@ -1,7 +1,0 @@
-namespace Infrastructure.Binance;
-
-public sealed class SystemClock : IBinanceClock
-{
-    public long UtcNowMsAdjusted() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-}
-

--- a/src/Infrastructure/Binance/TimeSyncClock.cs
+++ b/src/Infrastructure/Binance/TimeSyncClock.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Binance;
+
+public sealed class TimeSyncClock : IBinanceClock, IHostedService, IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly ILogger<TimeSyncClock> _logger;
+    private long _offsetMs;
+    private Timer? _timer;
+
+    public TimeSyncClock(IHttpClientFactory httpFactory, ILogger<TimeSyncClock> logger, IOptions<BinanceOptions> opt)
+    {
+        _http = httpFactory.CreateClient("BinancePublic");
+        _http.BaseAddress = new Uri(opt.Value.BaseUrl);
+        _logger = logger;
+    }
+
+    public long UtcNowMsAdjusted() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() + Interlocked.Read(ref _offsetMs);
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        _timer = new Timer(async _ => await Sync(ct), null, TimeSpan.Zero, TimeSpan.FromSeconds(30));
+        return Task.CompletedTask;
+    }
+
+    private async Task Sync(CancellationToken ct)
+    {
+        try
+        {
+            var resp = await _http.GetAsync("/fapi/v1/time", ct);
+            resp.EnsureSuccessStatusCode();
+            var json = await resp.Content.ReadFromJsonAsync<BinanceTimeDto>(cancellationToken: ct);
+            if (json?.serverTime is long serverMs)
+            {
+                var localMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                var off = serverMs - localMs;
+                Interlocked.Exchange(ref _offsetMs, off);
+                if (Math.Abs(off) > 1000)
+                    _logger.LogWarning("Binance time offset = {Off} ms", off);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to sync Binance time");
+        }
+    }
+
+    public Task StopAsync(CancellationToken ct)
+    {
+        _timer?.Dispose();
+        _timer = null;
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => _timer?.Dispose();
+
+    private sealed record BinanceTimeDto(long serverTime);
+}

--- a/tests/Infrastructure.Tests/BinanceSigningTests.cs
+++ b/tests/Infrastructure.Tests/BinanceSigningTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Net.Http;
 using System.Linq;
 using Infrastructure.Binance;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -41,25 +43,24 @@ public class BinanceSigningTests
         var handler = new FakeHandler();
         handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent("{\"serverTime\":1690000000000}")
-        });
-        handler.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
-        {
             Content = new StringContent("[]")
         });
 
         var http = new HttpClient(handler);
         var settings = new AppSettings { ApiKey = apiKey, ApiSecret = "testsecret" };
         var options = Options.Create(new BinanceOptions(true));
-        var signer = new Signer("testsecret");
-        var client = new BinanceFuturesClient(http, settings, options, signer);
+        var client = new BinanceFuturesClient(http, settings, options, new FakeClock(), NullLogger<BinanceFuturesClient>.Instance);
 
         await client.GetAccountBalanceAsync();
 
-        var req = handler.Requests.Last();
+        var req = handler.Requests.Single();
         Assert.Equal(HttpMethod.Get, req.Method);
         Assert.True(req.Headers.TryGetValues("X-MBX-APIKEY", out var values));
         Assert.Equal(apiKey, Assert.Single(values));
         Assert.Null(req.Content);
+    }
+    private sealed class FakeClock : IBinanceClock
+    {
+        public long UtcNowMsAdjusted() => 1690000000000;
     }
 }


### PR DESCRIPTION
## Summary
- sign requests using API secret with canonical encoding and debug logging
- add TimeSyncClock to sync with Binance server time and wire into DI
- include HttpResponse extensions for detailed error handling

## Testing
- `dotnet build BinanceBot.sln`
- `dotnet test`
- `BINANCE_API_KEY=dummy BINANCE_API_SECRET=dummy dotnet run --project BinanceBot.csproj` *(fails: API-key format invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68a51d3fb14c8330b0a7800de9dcdf81