### PR TITLE
Implement OrderSizingService and explicit stop logging

### DIFF
--- a/BinanceBot.Tests/OrderSizingServiceTests.cs
+++ b/BinanceBot.Tests/OrderSizingServiceTests.cs
@@ -14,7 +14,7 @@ public class OrderSizingServiceTests
         var ok = svc.TrySize("BTCUSDT", OrderType.Market, entryPrice:113985.80m, stopPrice:113985.80m - 4329.44m, riskUsd:150m,
                              out var qty, out var reason);
         Assert.True(ok);
-        Assert.True(qty >= 0.035m - 0.0005m);
+        Assert.Equal(0.034m, qty);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace ad-hoc sizing with `OrderSizingService.TrySize` that floors quantity to step size and enforces min qty/notional
- compute and log `stopDistanceUsd` and `stopPrice` for each trade
- expand unit tests for sizing scenarios

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a60a630f088330aaf5b128eb4c144d